### PR TITLE
Support resource format like "user:gpu_type"

### DIFF
--- a/slurm_gpustat/slurm_gpustat.py
+++ b/slurm_gpustat/slurm_gpustat.py
@@ -536,6 +536,8 @@ def gpu_usage(resources: dict, partition: Optional[str] = None) -> dict:
             continue
         gpu_count_str, node_str, user, jobid = tokens
         gpu_count_tokens = gpu_count_str.split(":")
+        if not gpu_count_tokens[-1].isdigit():
+            gpu_count_tokens.append('1')
         num_gpus = int(gpu_count_tokens[-1])
         # get detailed job information, to check if using bash
         detailed_output = parse_cmd(detailed_job_cmd % jobid, split=False)


### PR DESCRIPTION
Sometimes the resource format will not be in "user:gpu_type:gpu_num" or "user:gpu_num", but rather "user:gpu_type" which is equivalent to "uesr:gpu_type:1".